### PR TITLE
try the panel again if extensions are not running

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -8,7 +8,7 @@
       "strict_max_version": "86.0"
     }
   },
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Ask the user if they would like to use a specified search engine as the default.",
   "experiment_apis": {
     "search": {


### PR DESCRIPTION
This addresses the most probable reasons that the panel is not shown when maybe it should be.  One particular case is  https://bugzilla.mozilla.org/show_bug.cgi?id=1679861 where, within the same firefox session, the engine is not added back into search when un-blocklisted.  A restart of firefox is required before that works correctly.