### PR TITLE
add telemetry for showing the panel, update how we handle the preference

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -8,7 +8,7 @@
       "strict_max_version": "86.0"
     }
   },
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Ask the user if they would like to use a specified search engine as the default.",
   "experiment_apis": {
     "search": {


### PR DESCRIPTION
The pref is updated so that we can determine in any future update whether the panel was shown in a previous version.

A telemetry item is added for when we do show the panel.  The extension id of the addon we choose to show the panel for is passed as part of the data.

We'll also need data review on this, @kewisch will handle that.