### PR TITLE
Disable button on click

### DIFF
--- a/extension/searchdefault.js
+++ b/extension/searchdefault.js
@@ -40,9 +40,12 @@ async function promptResult(accept) {
 }
 
 document.getElementById("resetSearch").addEventListener("click", async (event) => {
+  this.disabled = true;
   promptResult(true);
 });
 
 document.getElementById("close").addEventListener("click", async (event) => {
+  document.getElementById("resetSearch").disabled = true;
+  this.disabled = true;
   promptResult(false);
 });


### PR DESCRIPTION
To avoid concurrent installations, disable the button when the user clicks on it.

There are two buttons: One to confirm, one to cancel basically.
To avoid repeated clicks (e.g. when the user touches multiple times via a touchpad), I disable the button upon click.
I'm keeping No non-disabled when Yes is clicked, in case Yes gets stuck on an error (to allow the user to close the tab via the close button).